### PR TITLE
FIX: webserver client body adjusted to 200mb, citations fix

### DIFF
--- a/deployment/nginx/nginx.conf
+++ b/deployment/nginx/nginx.conf
@@ -7,6 +7,7 @@ server {
     listen 80;
     listen [::]:80;
     server_name localhost;
+    client_max_body_size 200M;
 
     location / {
         proxy_pass http://streamlit;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+version: '3.0'
 
 services:
   streamlit:

--- a/omic_learn.py
+++ b/omic_learn.py
@@ -557,7 +557,7 @@ def generate_footer_parts():
     citations = """
         <br> <b>APA Format:</b> <br>
         Torun FM, Virreira Winter S, Doll S, Riese FM, Vorobyev A, Mueller-Reif JB, Geyer PE, Strauss MT (2021).
-        Transparent exploration of machine learning for biomarker discovery from proteomics and omics data. doi: 10.XXXX/XXXX.XX.XX.XXXXXX.
+        Transparent exploration of machine learning for biomarker discovery from proteomics and omics data. doi: https://doi.org/10.1101/2021.03.05.434053.
     """
 
     # Put the footer with tabs


### PR DESCRIPTION
Several small changes:
- Adjusted NGINX client body size to 200mb;
- Changed citations reference to https://doi.org/10.1101/2021.03.05.434053;
- Changed compose version from 3.8 to 3.0 to make it compatible with ECS task definitions.