### PR TITLE
FIX excel import with date columns

### DIFF
--- a/omic_learn.py
+++ b/omic_learn.py
@@ -111,7 +111,12 @@ def main_text_and_data_upload(state):
     st.markdown("By uploading a file, you agree that you accepting [the licence agreement](https://github.com/OmicEra/OmicLearn).")
     delimiter = st.selectbox("Determine the delimiter in your dataset", ["Excel File", "Comma (,)", "Semicolon (;)"])
     state['sample_file'] = st.selectbox("Or select sample file here:", ["None", "Alzheimer", "Sample"])
-    state['df'] = load_data(file_buffer, delimiter)
+
+    df, warnings = load_data(file_buffer, delimiter)
+
+    for warning in warnings:
+        st.warning(warning)
+    state['df'] = df
 
     return state
 

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -22,16 +22,16 @@ def test_load_data():
     writer = pd.ExcelWriter(output, engine='xlsxwriter')
     df.to_excel(writer, sheet_name='Sheet1', index=False)
     writer.save()
-    xlsx_data = load_data(output, 'Excel File')
+    xlsx_data, warnings = load_data(output, 'Excel File')
     pd.testing.assert_frame_equal(xlsx_data, df)
 
     # csv
     df = pd.DataFrame({'A': [1, 1], 'B': [0, 0]})
-    csv_data = load_data('test_csv_c.csv', 'Comma (,)')
+    csv_data, warnings = load_data('test_csv_c.csv', 'Comma (,)')
     print(csv_data)
     pd.testing.assert_frame_equal(csv_data, df)
 
-    csv_data = load_data('test_csv_sc.csv', 'Semicolon (;)')
+    csv_data, warnings = load_data('test_csv_sc.csv', 'Semicolon (;)')
     print(csv_data)
     pd.testing.assert_frame_equal(csv_data, df)
 

--- a/utils/helper.py
+++ b/utils/helper.py
@@ -49,15 +49,31 @@ def load_data(file_buffer, delimiter):
     """
     Load data to pandas dataframe
     """
+
+    warnings = []
     df = pd.DataFrame()
     if file_buffer is not None:
         if delimiter == "Excel File":
             df = pd.read_excel(file_buffer)
+
+            #check if all columns are strings valid_columns = []
+            error = False
+            valid_columns = []
+            for idx, _ in enumerate(df.columns):
+                if isinstance(_, str):
+                    valid_columns.append(_)
+                else:
+                    warnings.append(f'Removing column {idx} with value {_} as type is {type(_)} and not string.')
+                    error = True
+            if error:
+                warnings.append("Errors detected when importing Excel file. Please check that Excel did not convert protein names to dates.")
+                df = df[valid_columns]
+
         elif delimiter == "Comma (,)":
             df = pd.read_csv(file_buffer, sep=',')
         elif delimiter == "Semicolon (;)":
             df = pd.read_csv(file_buffer, sep=';')
-    return df
+    return df, warnings
 
 @st.cache(persist=True)
 def transform_dataset(subset, additional_features, proteins):
@@ -530,7 +546,7 @@ def plot_confusion_matrices(class_0, class_1, results, names):
     sliders = [dict(currentvalue={"prefix": "CV Split: "}, pad = {"t": 72}, active = 0, steps = steps)]
     p.layout.update(sliders=sliders)
     p.update_layout(autosize=False, width=700, height=700)
-    
+
     return p
 
 def plot_roc_curve_cv(roc_curve_results, cohort_combos = None):


### PR DESCRIPTION
Fixes a bug when trying to import excel files which have dates as columns headers.
This sometimes happens as Excel things some protein names are dates..

https://www.theverge.com/2020/8/6/21355674/human-genes-rename-microsoft-excel-misreading-dates