### PR TITLE
FEAT: new GithubActions workflows: create JIRA issue and update JIRA …

### DIFF
--- a/.github/workflows/create_jira_issue.yml
+++ b/.github/workflows/create_jira_issue.yml
@@ -1,0 +1,74 @@
+name: Create JIRA Issue
+on:
+  issues:
+    types: [opened]
+jobs:
+  jira:
+    name: Create an Issue in Jira with the GitHub issue information
+    runs-on: ubuntu-latest
+    env:
+      JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+      API_KEY: ${{ secrets.JIRA_API_KEY }}
+      JIRA_URL: ${{ secrets.JIRA_URL }}
+      JIRA_PROJECT_ID: ${{ secrets.JIRA_PROJECT_ID }}
+      JIRA_REPORTER: ${{ secrets.JIRA_REPORTER }}
+      JIRA_EPIC_ID: ${{ secrets.EPIC_ID }}
+    steps:
+      - name: Checkout Repository Code
+        uses: actions/checkout@v2
+      - name: Save Issue Information
+        id: issue-info
+        run: |
+         summary="${{ github.event.issue.title }}"
+         if [[ $summary == *"'"* ]]; then
+            summary=$(echo "${summary//\'/''}")
+         fi
+
+         description="${{ github.event.issue.body }}"
+         if [[ $description == *"'"* ]]; then
+            description=$(echo "${description//\'/''}")
+         fi
+
+         echo "::set-output name=summary::${summary}"
+         echo "::set-output name=description::${description}"
+      - name: Create a similar Issue in JIRA
+        run: |
+          result=$(curl --request POST \
+            --url '${{ env.JIRA_URL }}' \
+            --user '${{ env.JIRA_USER_EMAIL }}:${{ env.API_KEY }}' \
+            --header 'Accept: application/json' \
+            --header 'Content-Type: application/json' \
+            --data '
+              {
+                "fields": {
+              		"project": {
+                    "key": "${{ env.JIRA_PROJECT_ID }}"
+                  },
+              		"issuetype": {
+                    "name": "Bug"
+                  },
+                  "summary": "${{ steps.issue-info.outputs.summary }}",
+                  "description": "[Automated opening comment]: ${{ steps.issue-info.outputs.description }}",
+                  "reporter": {
+                    "id": "${{ env.JIRA_REPORTER }}"
+                  },
+              		"priority": {
+              			"name": "Medium"
+              		},
+                  "labels": [
+                    "bugfix",
+                    "github_created_issue"
+                  ],
+                  "customfield_10014": "${{ env.JIRA_EPIC_ID }}"
+                }
+              }
+            ')
+          issueID=$(echo $result | jq '.id')
+          if [ -z "issueID" ]; then
+            echo $result
+            echo "The workflow has failed."
+            exit 1
+          else
+            echo "Issue created successfully."
+            echo "Issue ID is ${issueID}"
+          fi

--- a/.github/workflows/update_jira_issue.yml
+++ b/.github/workflows/update_jira_issue.yml
@@ -1,0 +1,145 @@
+name: Update JIRA Issue
+on:
+  issues:
+    types: [reopened]
+jobs:
+  jira:
+    name: Update an Issue in Jira with the GitHub issue information
+    runs-on: ubuntu-latest
+    env:
+      JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+      API_KEY: ${{ secrets.JIRA_API_KEY }}
+      JIRA_URL: ${{ secrets.JIRA_URL }}
+      JIRA_PROJECT_ID: ${{ secrets.JIRA_PROJECT_ID }}
+      JIRA_REPORTER: ${{ secrets.JIRA_REPORTER }}
+      JIRA_EPIC_ID: ${{ secrets.EPIC_ID }}
+    steps:
+      - name: Checkout Repository Code
+        uses: actions/checkout@v2
+      - name: Save Issue Information
+        id: issue-info
+        run: |
+          unescaped_summary="${{ github.event.issue.title }}"
+          summary=$(echo ${unescaped_summary// /%20})
+          if [[ $summary == *"'"* ]]; then
+            summary=$(echo "${summary//\'/''}")
+          fi
+          description="${{ github.event.issue.body }}"
+          if [ -z "$description" ]; then
+             description="No description has been provided."
+          fi
+          if [[ $description == *"'"* ]]; then
+             description=$(echo "${description//\'/''}")
+          fi
+          echo "::set-output name=summary::${summary}"
+          echo "::set-output name=description::${description}"
+      - name: Check if the issue is already open in JIRA
+        id: issue-check
+        run: |
+          result=$(curl --request GET \
+            --url 'https://omicera.atlassian.net/rest/api/2/search?jql=summary~"${{ steps.issue-info.outputs.summary }}"&issuetypeNames=Bug&project=${{ secrets.JIRA_PROJECT_ID }}' \
+            --user '${{ env.JIRA_USER_EMAIL }}:${{ env.API_KEY }}' \
+            --header 'Accept: application/json' \
+            --header 'Content-Type: application/json')
+          totalResults=$(echo $result | jq '.total')
+          if [ "$totalResults" -eq "0" ]; then
+            echo "::set-output name=issueExists::False"
+          else
+            echo "::set-output name=issueExists::True"
+            issueID=$(echo $result | jq '.issues[0]["key"]')
+            temp="${issueID%\"}"
+            issueID="${temp#\"}"
+            echo "::set-output name=issue::$issueID"
+          fi
+      - name: Grab the comment body
+        if: steps.issue-check.outputs.issueExists == 'True'
+        id: comment-body
+        run: |
+          timestamp() {
+            date -u +"%Y-%m-%dT%H:%M:%SZ" -d "-1 min"
+          }
+          result_time=$(timestamp)
+          comment=$(curl -s "https://api.github.com/repos/OmicEra/aws-terraform-modules/issues/${{ github.event.issue.number }}/comments?since=$result_time" \
+                  -H "Accept: application/vnd.github.v3+json" \
+                  -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}")
+          if [ ${#comment[@]} -eq 0 ]; then
+            echo "Comment not found"
+            exit 1
+          fi
+          echo $comment
+          commentID=$(echo $comment | jq '.[0]["id"]')
+          commentBody=$(echo $comment | jq '.[0]["body"]')
+          temp="${commentBody%\"}"
+          commentBody="${temp#\"}"
+          if [[ $commentBody == *"'"* ]]; then
+            commentBody=$(echo "${commentBody//\'/''}")
+          fi
+          echo "Comment id is ${commentID}"
+          echo "Comment body is ${commentBody}"
+          echo "::set-output name=body::$commentBody"
+      - name: Update the existing issue in JIRA
+        if: steps.issue-check.outputs.issueExists == 'True'
+        run: |
+          result=$(curl --request POST \
+            --url 'https://omicera.atlassian.net/rest/api/2/issue/${{ steps.issue-check.outputs.issue }}/comment' \
+            --user '${{ env.JIRA_USER_EMAIL }}:${{ env.API_KEY }}' \
+            --header 'Accept: application/json' \
+            --header 'Content-Type: application/json' \
+            --data '
+              {
+                "body": "[Automated re-opening comment]: ${{ steps.comment-body.outputs.body }}"
+              }
+            ')
+          echo $result
+          issueID=$(echo $result | jq '.id')
+          if [ -z "issueID" ]; then
+            echo $result
+            echo "The workflow has failed."
+            exit 1
+          else
+            echo "Issue updated successfully."
+            echo "Issue ID is ${issueID}"
+          fi
+      - name: Create a similar Issue in JIRA
+        if: steps.issue-check.outputs.issueExists == 'False'
+        run: |
+          result=$(curl --request POST \
+            --url '${{ env.JIRA_URL }}' \
+            --user '${{ env.JIRA_USER_EMAIL }}:${{ env.API_KEY }}' \
+            --header 'Accept: application/json' \
+            --header 'Content-Type: application/json' \
+            --data '
+              {
+                "fields": {
+              		"project": {
+                    "key": "${{ env.JIRA_PROJECT_ID }}"
+                  },
+              		"issuetype": {
+                    "name": "Bug"
+                  },
+                  "summary": "${{ steps.issue-info.outputs.summary }}",
+                  "description": "[Automated opening comment]: ${{ steps.issue-info.outputs.description }}",
+                  "reporter": {
+                    "id": "${{ env.JIRA_REPORTER }}"
+                  },
+              		"priority": {
+              			"name": "Medium"
+              		},
+                  "labels": [
+                    "bugfix",
+                    "github_created_issue"
+                  ],
+                  "customfield_10014": "${{ env.JIRA_EPIC_ID }}"
+                }
+              }
+            ')
+          issueID=$(echo $result | jq '.id')
+          if [ -z "issueID" ]; then
+            echo $result
+            echo "The workflow has failed."
+            exit 1
+          else
+            echo "Issue created successfully."
+            echo "Issue ID is ${issueID}"
+          fi
+


### PR DESCRIPTION
Two new workflows for OmicLearn:

1. Workflow 1: 

- When an issue is opened in GitHub, create a "bug" issue in JIRA. The JIRA issue will be created under Data Science Project -> OmicLearn Epic
- The issue will be created without an Assignee
- Github issue summary -> JIRA issue title
- Github issue description -> JIRA issue description

2. Workflow 2:

- When an issue is reopened in GitHub, update an existing issue in JIRA with the re-opening comment.
- Github issue summary -> JIRA issue title
- Github issue comment -> JIRA issue comment